### PR TITLE
Updated link to ComfyUI Wrapper in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,7 @@ InstantCharacter is an innovative, tuning-free method designed to achieve charac
 
 ## Release
 
-- [2025/04/21] 🔥 Thanks to [jax-explorer](https://github.com/jax-explorer) for providing the [ComfyUI Warpper](https://instantcharacter.github.io/). 
-
-
+- [2025/04/21] 🔥 Thanks to [jax-explorer](https://github.com/jax-explorer) for providing the [ComfyUI Wrapper](https://github.com/jax-explorer/ComfyUI-InstantCharacter).
 - [2025/04/18] 🔥 We release the [demo](https://huggingface.co/spaces/InstantX/InstantCharacter) [checkpoints](https://huggingface.co/InstantX/InstantCharacter/) and [code](https://github.com/Tencent/InstantCharacter).
 <!-- - [2025/04/02] 🔥 We release the [technical report](https://xxxxxxx/). -->
 - [2025/04/02] 🔥 We launch the [project page](https://instantcharacter.github.io/).


### PR DESCRIPTION
The link to the ComfyUI wrapper in the readme had two issues: a typo and it was linking to the github page of InstantCharacter instead of jax-explorer's repo.